### PR TITLE
merge Dockerfiles into one

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,7 +52,7 @@ dockers:
     goos: linux
     # GOARCH of the built binary that should be used.
     goarch: amd64
-    dockerfile: Dockerfile.release
+    dockerfile: Dockerfile
     image_templates:
       - "y4m4/s3www:{{ .Tag }}"
       - "y4m4/s3www:latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,11 @@
 FROM golang:1.14
 
-ADD go.mod /go/src/github.com/harshavardhana/s3www/go.mod
-ADD go.sum /go/src/github.com/harshavardhana/s3www/go.sum
-WORKDIR /go/src/github.com/harshavardhana/s3www/
-# Get dependencies - will also be cached if we won't change mod/sum
-RUN go mod download
-
-ADD . /go/src/github.com/harshavardhana/s3www/
-WORKDIR /go/src/github.com/harshavardhana/s3www/
-
-ENV CGO_ENABLED=0
-
-RUN go build -ldflags '-w -s' -a -o s3www .
-
 FROM scratch
 EXPOSE 8080
 
 # Copy CA certificates to prevent x509: certificate signed by unknown authority errors
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-COPY --from=0 /go/src/github.com/harshavardhana/s3www/s3www /s3www
+COPY s3www /s3www
 
 ENTRYPOINT ["/s3www"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,5 +1,0 @@
-FROM scratch
-EXPOSE 8080
-COPY s3www /s3www
-
-ENTRYPOINT ["/s3www"]


### PR DESCRIPTION
I noticed that the docker images for `v0.4.3` and `v0.4.4` do not include the fix introduced in #7.

That is probably because the _goreleaser_ config doesn't use the Dockerfile where that fix was applied.

To prevent this I merged the two Dockerfiles into one and also created a github action that runs _goreleaser_. Releasing should be as easy as pushing a tag :tada: 

You would have to add two secrets: `DOCKER_USERNAME` and `DOCKER_PASSWORD`