### PR TITLE
Added proper check for if path is directory

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func pathIsDir(ctx context.Context, s3 *S3, name string) bool {
 			Prefix:  name,
 			MaxKeys: 1,
 		})
-	for _ = range objCh {
+	for range objCh {
 		cancel()
 		return true
 	}


### PR DESCRIPTION
Fixes https://github.com/harshavardhana/s3www/issues/6

The http.FileServer strips trailing slashes from requests. To alleviate this problem, we instead check if any files exist that have the prefix. If they do, then we serve the file as a directory.