### PR TITLE
adding example IAM policy, 0.5.0 added requirement for s3:ListBucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,29 @@ s3www: Started listening on https://example.com
 
 Point your web browser to https://example.com ensure your `s3www` is serving your `index.html` successfully.
 
+## Permissions 
+
+### AWS IAM Policy
+s3www requires access to view and list all files in the bucket.
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::<Bucket Name>/*"
+        },
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::<Bucket Name>"
+        }
+    ]
+}
+```
 # License
 This project is distributed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0), see [LICENSE](./LICENSE) for more information.


### PR DESCRIPTION
I can only speak for AWS as it is the only place I am using s3www.

v0.5.0 added a requirement for `s3:ListBucket` (in addition to previously only needing `s3:GetObject`).

This PR adds and example IAM policy for the minimum required permissions.