### PR TITLE
Fix S3 file server edge cases

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func (s3 *S3) Open(name string) (http.File, error) {
 			client: s3.Client,
 			object: nil,
 			isDir:  true,
-			bucket: bucket,
+			bucket: s3.bucket,
 			prefix: strings.TrimSuffix(name, pathSeparator),
 		}, nil
 	}
@@ -92,7 +92,7 @@ func (s3 *S3) Open(name string) (http.File, error) {
 		client: s3.Client,
 		object: obj,
 		isDir:  false,
-		bucket: bucket,
+		bucket: s3.bucket,
 		prefix: name,
 	}, nil
 }
@@ -102,7 +102,7 @@ func getObject(ctx context.Context, s3 *S3, name string) (*minio.Object, error) 
 	if spaFile != "" {
 		names = append(names, spaFile)
 	}
-	names = append(names, "/404.html")
+	names = append(names, "404.html")
 	for _, n := range names {
 		obj, err := s3.GetObject(ctx, s3.bucket, n, minio.GetObjectOptions{})
 		if err != nil {

--- a/object.go
+++ b/object.go
@@ -38,7 +38,10 @@ type httpMinioObject struct {
 }
 
 func (h *httpMinioObject) Close() error {
-	return h.object.Close()
+	if h.object != nil {
+		return h.object.Close()
+	}
+	return nil
 }
 
 func (h *httpMinioObject) Read(p []byte) (n int, err error) {


### PR DESCRIPTION
## Summary
- fix nil pointer on directory close
- use S3 bucket field consistently
- correct 404 lookup path

## Testing
- `go build ./...` *(fails: access to storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_b_686aea4002a08329b46a66980e257d92