### PR TITLE
getObject: close object handle on Stat failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,6 +112,8 @@ func getObject(ctx context.Context, s3 *S3, name string) (*minio.Object, error) 
 
 		_, err = obj.Stat()
 		if err != nil {
+			obj.Close()
+
 			// do not log "file" in bucket not found errors
 			if minio.ToErrorResponse(err).Code != "NoSuchKey" {
 				log.Println(err)


### PR DESCRIPTION
When GetObject succeeds but Stat fails, the object handle was discarded without Close(), leaking the underlying connection.