### PR TITLE
pathIsDir: check object.Err instead of silently treating errors as directory exists

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,7 +62,10 @@ func pathIsDir(ctx context.Context, s3 *S3, name string) bool {
 			Prefix:  name,
 			MaxKeys: 1,
 		})
-	for range objCh {
+	for object := range objCh {
+		if object.Err != nil {
+			return false
+		}
 		cancel()
 		return true
 	}


### PR DESCRIPTION
The 'for range objCh' loop discarded the channel value, so S3 error entries (network issues, auth failures) were treated as proof that a directory exists. Capture the value and check object.Err, returning false when an error is encountered.